### PR TITLE
Added presentedVC top offset customisation option

### DIFF
--- a/DeckTransition/Classes/DeckPresentationController.swift
+++ b/DeckTransition/Classes/DeckPresentationController.swift
@@ -24,7 +24,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
     var pan: UIPanGestureRecognizer?
 	
 	// MARK:- Private variables
-	
+    private var presentTopOffset: CGFloat = kDefaultPresentTopOffset
 	private var presentAnimation: (() -> ())? = nil
 	private var presentCompletion: ((Bool) -> ())? = nil
 	private var dismissAnimation: (() -> ())? = nil
@@ -32,12 +32,13 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
 	
 	// MARK:- Initializers
 	
-	convenience init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, presentAnimation: (() -> ())? = nil, presentCompletion: ((Bool) ->())? = nil, dismissAnimation: (() -> ())? = nil, dismissCompletion: ((Bool) -> ())? = nil) {
+    convenience init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, presentTopOffset: CGFloat = kDefaultPresentTopOffset, presentAnimation: (() -> ())? = nil, presentCompletion: ((Bool) ->())? = nil, dismissAnimation: (() -> ())? = nil, dismissCompletion: ((Bool) -> ())? = nil) {
 		self.init(presentedViewController: presentedViewController, presenting: presentingViewController)
 		self.presentAnimation = presentAnimation
 		self.presentCompletion = presentCompletion
 		self.dismissAnimation = dismissAnimation
 		self.dismissCompletion = dismissCompletion
+        self.presentTopOffset = presentTopOffset
 	}
 	
     /**
@@ -47,7 +48,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
     */
     override var frameOfPresentedViewInContainerView: CGRect {
         if let view = containerView {
-            let offset: CGFloat = 28
+            let offset: CGFloat = presentTopOffset
             return CGRect(x: 0, y: offset, width: view.bounds.width, height: view.bounds.height - offset)
         } else {
             return .zero

--- a/DeckTransition/Classes/DeckTransitioningDelegate.swift
+++ b/DeckTransition/Classes/DeckTransitioningDelegate.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+internal let kDefaultPresentTopOffset: CGFloat = 28
+
 public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate, DeckPresentationControllerDelegate {
 	
 	// MARK:- Public variables
@@ -25,6 +27,7 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
 	// MARK:- Private variables
 	
 	private let presentDuration: TimeInterval?
+    private var presentTopOffset: CGFloat = kDefaultPresentTopOffset
 	private let presentAnimation: (() -> ())?
 	private let presentCompletion: ((Bool) -> ())?
 	private let dismissDuration: TimeInterval?
@@ -46,8 +49,9 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
 	///		alongside the card dismissal animation
 	///   - dismissCompletion: A block that will be run after the card has been
 	///		dismissed
-	public init(presentDuration: TimeInterval? = nil, presentAnimation: (() -> ())? = nil, presentCompletion: ((Bool) ->())? = nil, dismissDuration: TimeInterval? = nil, dismissAnimation: (() -> ())? = nil, dismissCompletion: ((Bool) -> ())? = nil) {
+    public init(presentDuration: TimeInterval? = nil, presentTopOffset: CGFloat = kDefaultPresentTopOffset, presentAnimation: (() -> ())? = nil, presentCompletion: ((Bool) ->())? = nil, dismissDuration: TimeInterval? = nil, dismissAnimation: (() -> ())? = nil, dismissCompletion: ((Bool) -> ())? = nil) {
 		self.presentDuration = presentDuration
+        self.presentTopOffset = presentTopOffset
 		self.presentAnimation = presentAnimation
 		self.presentCompletion = presentCompletion
 		self.dismissDuration = dismissDuration
@@ -75,6 +79,7 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
         let presentationController = DeckPresentationController(
 			presentedViewController: presented,
 			presenting: presenting,
+			presentTopOffset: presentTopOffset,
 			presentAnimation: presentAnimation,
 			presentCompletion: presentCompletion,
 			dismissAnimation: dismissAnimation,


### PR DESCRIPTION
I wanted to be able to customise the top offset of the presented ViewController, so I've added in a new property in the `DeckTransitioningDelegate` and `DeckPresentationController`,  that allows for this.

It is an optional argument to the existing constructors, that defaults to 28. Existing call sites will not be affected.

Because the top offset could be large enough that the user could tap on the background, I've also added a tap gesture to dismiss the modal by tapping there.

Regards,
Arvindh