### PR TITLE
Fixed transform issue if modalVC is retained and re-presented

### DIFF
--- a/DeckTransition/Classes/DeckPresentationController.swift
+++ b/DeckTransition/Classes/DeckPresentationController.swift
@@ -96,7 +96,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
             if let view = containerView {
                 let offScreenFrame = CGRect(x: 0, y: view.bounds.height, width: view.bounds.width, height: view.bounds.height)
                 presentedViewController.view.frame = offScreenFrame
-				presentedViewController.view.transform = .identity
+                presentedViewController.view.transform = .identity
             }
         }
 		

--- a/DeckTransition/Classes/DeckPresentationController.swift
+++ b/DeckTransition/Classes/DeckPresentationController.swift
@@ -96,6 +96,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
             if let view = containerView {
                 let offScreenFrame = CGRect(x: 0, y: view.bounds.height, width: view.bounds.width, height: view.bounds.height)
                 presentedViewController.view.frame = offScreenFrame
+				presentedViewController.view.transform = .identity
             }
         }
 		


### PR DESCRIPTION
If a reference to the modal view controller is maintained, and the same controller is presented again after dismissal, there is an issue when flicking-to-scroll. 

Steps to reproduce:
- Create a property on the presenting VC, maintaining a reference to the modal VC.
- Present and dismiss the modal once.
- Re-present the modal, and attempt to scroll by flicking.

I suspect this is because the VC's transform is not reset after dismissal, and doing so seems to fix the issue.