### PR TITLE
Replaced the fullscreen mask with a rounded view

### DIFF
--- a/DeckTransition/Classes/DeckPresentationController.swift
+++ b/DeckTransition/Classes/DeckPresentationController.swift
@@ -285,9 +285,17 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
 			return
 		}
 		
+		/// The height is a bit higher than the rounded view to accomodate for
+		/// a black line that flickers sometimes because diffing floating points
+		/// is weird
+		let newRect = CGRect(x: roundedView.bounds.origin.x,
+		                     y: roundedView.bounds.origin.y,
+		                     width: roundedView.bounds.width,
+		                     height: roundedView.bounds.height + 2)
+		
 		let radii = CGSize(width: roundedView.bounds.height, height: roundedView.bounds.height)
-		let boundsPath = UIBezierPath(rect: roundedView.bounds)
-		boundsPath.append(UIBezierPath(roundedRect: roundedView.bounds,
+		let boundsPath = UIBezierPath(rect: newRect)
+		boundsPath.append(UIBezierPath(roundedRect: newRect,
 		                               byRoundingCorners: [.topLeft, .topRight],
 		                               cornerRadii: radii))
 		

--- a/Example/DeckTransition/ModalViewController.swift
+++ b/Example/DeckTransition/ModalViewController.swift
@@ -53,7 +53,9 @@ class ModalViewController: UIViewController, UITextViewDelegate {
 			} else {
 				if scrollView.isDecelerating {
 					view.transform = CGAffineTransform(translationX: 0, y: -scrollView.contentOffset.y)
-					scrollView.transform = CGAffineTransform(translationX: 0, y: scrollView.contentOffset.y)
+					scrollView.subviews.forEach {
+						$0.transform = CGAffineTransform(translationX: 0, y: scrollView.contentOffset.y)
+					}
 				} else {
 					scrollView.bounces = false
 					delegate.isDismissEnabled = true

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ func scrollViewDidScroll(_ scrollView: UIScrollView) {
                 // that means a swipe has been performed. The view and scrollview are
                 // both translated in response to this.
                 view.transform = CGAffineTransform(translationX: 0, y: -scrollView.contentOffset.y)
-                scrollView.transform = CGAffineTransform(translationX: 0, y: scrollView.contentOffset.y)
+                scrollView.subviews.forEach {
+                    $0.transform = CGAffineTransform(translationX: 0, y: scrollView.contentOffset.y)
+                }
             } else {
                 // If the user has panned to the top, the scrollview doesnʼt bounce and
                 // the dismiss gesture is enabled.


### PR DESCRIPTION
This PR replaced the existing fullscreen mask with a custom view. H/T to @rinat-gabdullin for the idea.

The view's position is updated by KVO-ing the presenting view's frame and transform, and this also requires some other changes on the user's end. The example and ReadMe have been updated to reflect that