### PR TITLE
Limit source file types to Swift and headers

### DIFF
--- a/DeckTransition.podspec
+++ b/DeckTransition.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.social_media_url = 'https://twitter.com/harshilshah1910'
 
   spec.source           = { :git => 'https://github.com/HarshilShah/DeckTransition.git', :tag => spec.version.to_s }
-  spec.source_files     = 'Source/**/*'
+  spec.source_files     = 'Source/**/*.{h,swift}'
 
   spec.framework        = 'UIKit'
   spec.ios.deployment_target = '9.0'


### PR DESCRIPTION
This fixes a bug where the Info.plist file from this repo was included
in the compile sources phase, which causes a build failure with the new
Xcode 9 build system.