### PR TITLE
Support for safe area based layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ func scrollViewDidScroll(_ scrollView: UIScrollView) {
 }
 ```
 
+### Snapshots
+
+For a variety of reasons, and especially because of iOS 11's safe area layout, DeckTransition uses a snapshot of your presenting view controller's view instead of using the view directly. This view is automatically updated whenever the frame is resized.
+
+However, there can be some cases where you might want to update the snapshot view by yourself, and this can be achieved using the following one line snippet:
+
+```swift
+(presentationController as? DeckSnapshotUpdater)?.requestPresentedViewSnapshotUpdate()
+```
+
+All this does is request the presentation controller to update the snapshot.
+
+You can also choose to update snapshot directly from the presenting view controller, as follows:
+
+```swift
+(presentedViewController?.presentationController as? DeckSnapshotUpdater)?.requestPresentedViewSnapshotUpdate()
+```
+
+It's worth noting that updating the snapshot is an expensive process and should only be used if necessary, for example if you are updating your entire app's theme.
+
 ## Apps Using DeckTransition
 - [Petty](https://zachsim.one/projects/petty) by [Zach Simone](https://twitter.com/zachsimone)
 - [Bitbook](https://bitbookapp.com) by [Sammy Gutierrez](https://sammygutierrez.com)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Feel free to submit a PR if you’re using this library in your apps
 
 ## Author
 
-Written by Harshil Shah. You can [find me on Twitter](https://twitter.com/HarshilShah1910) if you have any suggestions, requests, or just want to talk!
+Written by [Harshil Shah](https://twitter.com/HarshilShah1910)
 
 ## License
 

--- a/Source/DeckDismissingAnimationController.swift
+++ b/Source/DeckDismissingAnimationController.swift
@@ -13,15 +13,11 @@ final class DeckDismissingAnimationController: NSObject, UIViewControllerAnimate
 	// MARK:- Private variables
 	
 	private let duration: TimeInterval?
-	private let animation: (() -> ())?
-	private let completion: ((Bool) -> ())?
 	
 	// MARK:- Initializers
 	
-	init(duration: TimeInterval?, animation: (() -> ())?, completion: ((Bool) -> ())?) {
+	init(duration: TimeInterval?) {
 		self.duration = duration
-		self.animation = animation
-		self.completion = completion
 	}
 	
 	// MARK:- UIViewControllerAnimatedTransitioning
@@ -33,18 +29,16 @@ final class DeckDismissingAnimationController: NSObject, UIViewControllerAnimate
         
         let containerView = transitionContext.containerView
         
-        let offScreenFrame = CGRect(x: 0, y: containerView.bounds.height, width: containerView.bounds.width, height: containerView.bounds.height)
+        let offscreenFrame = CGRect(x: 0, y: containerView.bounds.height, width: containerView.bounds.width, height: containerView.bounds.height)
       
         UIView.animate(
             withDuration: transitionDuration(using: transitionContext),
             delay: 0,
             options: .curveEaseOut,
-            animations: { [weak self] in
-                presentedViewController.view.frame = offScreenFrame
-				self?.animation?()
-            }, completion: { [weak self] finished in
+            animations: {
+                presentedViewController.view.frame = offscreenFrame
+            }, completion: { finished in
                 transitionContext.completeTransition(finished)
-				self?.completion?(finished)
             })
     }
     

--- a/Source/DeckDismissingAnimationController.swift
+++ b/Source/DeckDismissingAnimationController.swift
@@ -23,7 +23,17 @@ final class DeckDismissingAnimationController: NSObject, UIViewControllerAnimate
 	// MARK:- UIViewControllerAnimatedTransitioning
 	
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        guard let presentedViewController = transitionContext.viewController(forKey: .from) else {
+        
+        /// The presentedViewController throughout this library refers to the
+        /// card view controller which is presented in the Deck style, and so
+        /// for consistency, even through it's the view controller that we are
+        /// transitioning `.from` in the context of the dismissal animation and
+        /// should thus be the `presentingViewController`, it's referred to as
+        /// the `presentedViewController` here
+        
+        guard let presentedViewController = transitionContext.viewController(forKey: .from),
+              let presentingViewController = transitionContext.viewController(forKey: .to)
+        else {
             return
         }
         
@@ -31,6 +41,9 @@ final class DeckDismissingAnimationController: NSObject, UIViewControllerAnimate
         
         let offscreenFrame = CGRect(x: 0, y: containerView.bounds.height, width: containerView.bounds.width, height: containerView.bounds.height)
       
+        presentedViewController.beginAppearanceTransition(false, animated: true)
+        presentingViewController.beginAppearanceTransition(true, animated: true)
+        
         UIView.animate(
             withDuration: transitionDuration(using: transitionContext),
             delay: 0,
@@ -39,6 +52,8 @@ final class DeckDismissingAnimationController: NSObject, UIViewControllerAnimate
                 presentedViewController.view.frame = offscreenFrame
             }, completion: { finished in
                 transitionContext.completeTransition(finished)
+                presentedViewController.endAppearanceTransition()
+                presentingViewController.endAppearanceTransition()
             })
     }
     

--- a/Source/DeckDismissingAnimationController.swift
+++ b/Source/DeckDismissingAnimationController.swift
@@ -27,41 +27,11 @@ final class DeckDismissingAnimationController: NSObject, UIViewControllerAnimate
 	// MARK:- UIViewControllerAnimatedTransitioning
 	
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        let presentingViewController = transitionContext.viewController(forKey: .to)!
-        let presentedViewController = transitionContext.viewController(forKey: .from)!
+        guard let presentedViewController = transitionContext.viewController(forKey: .from) else {
+            return
+        }
         
         let containerView = transitionContext.containerView
-        
-        let roundedViewForPresentingView = RoundedView()
-        roundedViewForPresentingView.cornerRadius = Constants.cornerRadius
-        roundedViewForPresentingView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.addSubview(roundedViewForPresentingView)
-        
-        /// At the end of the transition the rounded view has to have the same
-        /// frame as the presentingView, except with a height equal to the
-        /// cornerRadius
-        let finalFrameForPresentingView = transitionContext.finalFrame(for: presentingViewController)
-        let finalFrameForRoundedViewForPresentingView = CGRect(
-            x: finalFrameForPresentingView.origin.x,
-            y: finalFrameForPresentingView.origin.y,
-            width: finalFrameForPresentingView.width,
-            height: Constants.cornerRadius)
-        roundedViewForPresentingView.frame = finalFrameForRoundedViewForPresentingView
-        
-        let scale: CGFloat = 1 - (ManualLayout.presentingViewTopInset * 2 / finalFrameForPresentingView.height)
-        
-        /// The rounded view needs to be scaled by the same amount as the
-        /// presentingView, and also translated down by the same amount.
-        /// Scaling happens with respect to the frame's center, so a
-        /// translate-scale-translate needs to be done to ensure that the
-        /// scaling is performed with respect to the top edge so it still lines
-        /// up with the top edge of the presentingView
-        let transformForRoundedViewForPresentingView = CGAffineTransform.identity
-            .translatedBy(x: 0, y: ManualLayout.presentingViewTopInset)
-            .translatedBy(x: 0, y: -finalFrameForRoundedViewForPresentingView.height / 2)
-            .scaledBy(x: scale, y: scale)
-            .translatedBy(x: 0, y: finalFrameForRoundedViewForPresentingView.height / 2)
-        roundedViewForPresentingView.transform = transformForRoundedViewForPresentingView
         
         let offScreenFrame = CGRect(x: 0, y: containerView.bounds.height, width: containerView.bounds.width, height: containerView.bounds.height)
       
@@ -70,15 +40,9 @@ final class DeckDismissingAnimationController: NSObject, UIViewControllerAnimate
             delay: 0,
             options: .curveEaseOut,
             animations: { [weak self] in
-                roundedViewForPresentingView.transform = .identity
-                
-                presentingViewController.view.alpha = 1
-                presentingViewController.view.transform = .identity
-                
                 presentedViewController.view.frame = offScreenFrame
 				self?.animation?()
             }, completion: { [weak self] finished in
-                roundedViewForPresentingView.removeFromSuperview()
                 transitionContext.completeTransition(finished)
 				self?.completion?(finished)
             })

--- a/Source/DeckPresentingAnimationController.swift
+++ b/Source/DeckPresentingAnimationController.swift
@@ -13,15 +13,11 @@ final class DeckPresentingAnimationController: NSObject, UIViewControllerAnimate
 	// MARK:- Private variables
 	
 	private let duration: TimeInterval?
-	private let animation: (() -> ())?
-	private let completion: ((Bool) -> ())?
 	
 	// MARK:- Initializers
 	
-	init(duration: TimeInterval?, animation: (() -> ())?, completion: ((Bool) -> ())?) {
+	init(duration: TimeInterval?) {
 		self.duration = duration
-		self.animation = animation
-		self.completion = completion
 	}
 	
 	// MARK:- UIViewControllerAnimatedTransitioning
@@ -41,12 +37,10 @@ final class DeckPresentingAnimationController: NSObject, UIViewControllerAnimate
             withDuration: transitionDuration(using: transitionContext),
             delay: 0,
             options: .curveEaseOut,
-            animations: { [weak self] in
+            animations: {
                 presentedViewController.view.frame = finalFrameForPresentedView
-				self?.animation?()
-            }, completion: { [weak self] finished in
+            }, completion: { finished in
                 transitionContext.completeTransition(finished)
-                self?.completion?(finished)
             }
         )
     }

--- a/Source/DeckPresentingAnimationController.swift
+++ b/Source/DeckPresentingAnimationController.swift
@@ -27,71 +27,24 @@ final class DeckPresentingAnimationController: NSObject, UIViewControllerAnimate
 	// MARK:- UIViewControllerAnimatedTransitioning
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        let presentingViewController = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.from)!
-        let presentedViewController = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to)!
+        guard let presentedViewController = transitionContext.viewController(forKey: .to) else {
+            return
+        }
         
         let containerView = transitionContext.containerView
-        
-        let scale: CGFloat = 1 - (ManualLayout.presentingViewTopInset * 2 / presentingViewController.view.frame.height)
-        
-        let roundedViewForPresentingView = RoundedView()
-        roundedViewForPresentingView.cornerRadius = Constants.cornerRadius
-        roundedViewForPresentingView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.addSubview(roundedViewForPresentingView)
-        
-        /// Initially the rounded view has the same frame as the presentingView,
-        /// except with a height equal to the cornerRadius
-        let initialFrameForRoundedViewForPresentingView = CGRect(
-            x: presentingViewController.view.frame.origin.x,
-            y: presentingViewController.view.frame.origin.y,
-            width: presentingViewController.view.frame.width,
-            height: Constants.cornerRadius)
-        roundedViewForPresentingView.frame = initialFrameForRoundedViewForPresentingView
-        
-        /// The rounded view needs to be scaled by the same amount as the
-        /// presentingView, and also translated down by the same amount.
-        /// Scaling happens with respect to the frame's center, so a
-        /// translate-scale-translate needs to be done to ensure that the
-        /// scaling is performed with respect to the top edge so it still lines
-        /// up with the top edge of the presentingView
-        let transformForRoundedViewForPresentingView = CGAffineTransform.identity
-            .translatedBy(x: 0, y: ManualLayout.presentingViewTopInset)
-            .translatedBy(x: 0, y: -initialFrameForRoundedViewForPresentingView.height / 2)
-            .scaledBy(x: scale, y: scale)
-            .translatedBy(x: 0, y: initialFrameForRoundedViewForPresentingView.height / 2)
-        
         containerView.addSubview(presentedViewController.view)
         presentedViewController.view.frame = CGRect(x: 0, y: containerView.bounds.height, width: containerView.bounds.width, height: containerView.bounds.height)
         
-        let roundedViewForPresentedView = RoundedView()
-        containerView.addSubview(roundedViewForPresentedView)
-        roundedViewForPresentedView.frame = CGRect(x: 0, y: containerView.bounds.height, width: containerView.bounds.width, height: Constants.cornerRadius)
-        
         let finalFrameForPresentedView = transitionContext.finalFrame(for: presentedViewController)
-        let finalFrameForRoundedViewForPresentedView = CGRect(
-            x: finalFrameForPresentedView.origin.x,
-            y: finalFrameForPresentedView.origin.y,
-            width: finalFrameForPresentedView.width,
-            height: Constants.cornerRadius)
         
         UIView.animate(
             withDuration: transitionDuration(using: transitionContext),
             delay: 0,
             options: .curveEaseOut,
             animations: { [weak self] in
-                presentingViewController.view.transform = CGAffineTransform(scaleX: scale, y: scale)
-                presentingViewController.view.alpha = Constants.alphaForPresentingView
-                
-                roundedViewForPresentingView.cornerRadius = Constants.cornerRadius
-                roundedViewForPresentingView.transform = transformForRoundedViewForPresentingView
-				
                 presentedViewController.view.frame = finalFrameForPresentedView
-                roundedViewForPresentedView.frame = finalFrameForRoundedViewForPresentedView
-                
 				self?.animation?()
             }, completion: { [weak self] finished in
-                roundedViewForPresentingView.removeFromSuperview()
-                roundedViewForPresentedView.removeFromSuperview()
                 transitionContext.completeTransition(finished)
                 self?.completion?(finished)
             }

--- a/Source/DeckPresentingAnimationController.swift
+++ b/Source/DeckPresentingAnimationController.swift
@@ -23,7 +23,9 @@ final class DeckPresentingAnimationController: NSObject, UIViewControllerAnimate
 	// MARK:- UIViewControllerAnimatedTransitioning
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        guard let presentedViewController = transitionContext.viewController(forKey: .to) else {
+        guard let presentedViewController = transitionContext.viewController(forKey: .to),
+              let presentingViewController = transitionContext.viewController(forKey: .from)
+        else {
             return
         }
         
@@ -33,6 +35,9 @@ final class DeckPresentingAnimationController: NSObject, UIViewControllerAnimate
         
         let finalFrameForPresentedView = transitionContext.finalFrame(for: presentedViewController)
         
+        presentedViewController.beginAppearanceTransition(true, animated: true)
+        presentingViewController.beginAppearanceTransition(false, animated: true)
+        
         UIView.animate(
             withDuration: transitionDuration(using: transitionContext),
             delay: 0,
@@ -41,6 +46,8 @@ final class DeckPresentingAnimationController: NSObject, UIViewControllerAnimate
                 presentedViewController.view.frame = finalFrameForPresentedView
             }, completion: { finished in
                 transitionContext.completeTransition(finished)
+                presentedViewController.endAppearanceTransition()
+                presentingViewController.endAppearanceTransition()
             }
         )
     }

--- a/Source/DeckTransitioningDelegate.swift
+++ b/Source/DeckTransitioningDelegate.swift
@@ -62,17 +62,11 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
 	// MARK:- UIViewControllerTransitioningDelegate
     
     public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return DeckPresentingAnimationController(
-			duration: presentDuration,
-			animation: presentAnimation,
-			completion: presentCompletion)
+        return DeckPresentingAnimationController(duration: presentDuration)
     }
     
     public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return DeckDismissingAnimationController(
-			duration: dismissDuration,
-			animation: dismissAnimation,
-			completion: dismissCompletion)
+        return DeckDismissingAnimationController(duration: dismissDuration)
     }
     
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {


### PR DESCRIPTION
This is a major restructuring of how the library works. iOS 11 demands layout to be done with respect to safe area layouts, and those break completely when transforms are applied.

The goal here is to ensure that this never happens, by removing transforms entirely in favour of snapshot views, so that views are laid out as if with safe areas intact