### PR TITLE
releasing scrollViewUpdater on pan .ended, to stop observing

### DIFF
--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -586,7 +586,8 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
                 animations: {
                     self.presentedView?.transform = .identity
                 })
-        
+            scrollViewUpdater = nil
+
         default: break
         
         }


### PR DESCRIPTION
This prevents crashing if DeckPresentationController contains a table view, since scrollViewUpdater observes contentOffset and results in crash when table view displayed is eventually released while still having this KVO observer:

Fatal Exception: NSInternalInconsistencyException
An instance 0x132094a00 of class UITableView was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x174626680> ( <NSKeyValueObservance 0x17485da60: Observer: 0x175e74cc0, Key path: contentOffset, Options: <New: NO, Old: NO, Prior: NO> Context: 0x0, Property: 0x170a50890> )