### PR TITLE
Use preferredContentSize of the presentedviewController

### DIFF
--- a/Example/Source/ModalViewController.swift
+++ b/Example/Source/ModalViewController.swift
@@ -51,6 +51,13 @@ class ModalViewController: UIViewController {
         present(modal, animated: true, completion: nil)
     }
     
+    override var preferredContentSize: CGSize {
+        get {
+            return CGSize.init(width: self.view.frame.size.width, height: 400)
+        }
+        set { super.preferredContentSize = newValue }
+    }
+    
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }

--- a/Example/Source/Supporting Files/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Source/Supporting Files/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -99,6 +99,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    },
+    {
       "idiom" : "car",
       "size" : "60x60",
       "scale" : "2x"

--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -94,11 +94,14 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
         }
         
         let yOffset = ManualLayout.presentingViewTopInset + Constants.insetForPresentedView
+        let viewHeight = containerView.bounds.height - yOffset
+        let topOffset = (viewHeight-presentedViewController.preferredContentSize.height) as CGFloat
+        let height = viewHeight - topOffset
         
         return CGRect(x: 0,
-                      y: yOffset,
+                      y: yOffset+topOffset,
                       width: containerView.bounds.width,
-                      height: containerView.bounds.height - yOffset)
+                      height: height)
     }
 	
 	// MARK: - Presentation


### PR DESCRIPTION
This PR will add some new functionality to the library. It allows for smaller, sheet-like cards. It does this by using the `height` property of the `preferredContentSize` of the presented view controller.