### PR TITLE
Modifiable dismissThreshold

### DIFF
--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -35,7 +35,7 @@ class ViewController: UIViewController {
     
     @objc func viewWasTapped() {
         let modal = ModalViewController()
-        let transitionDelegate = DeckTransitioningDelegate()
+        let transitionDelegate = DeckTransitioningDelegate(dismissThreshold: 120)
         modal.transitioningDelegate = transitionDelegate
         modal.modalPresentationStyle = .custom
         present(modal, animated: true, completion: nil)

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -35,7 +35,7 @@ class ViewController: UIViewController {
     
     @objc func viewWasTapped() {
         let modal = ModalViewController()
-        let transitionDelegate = DeckTransitioningDelegate(dismissThreshold: 120)
+        let transitionDelegate = DeckTransitioningDelegate(dismissThreshold: 120, extraVerticalInset: 200)
         modal.transitioningDelegate = transitionDelegate
         modal.modalPresentationStyle = .custom
         present(modal, animated: true, completion: nil)

--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -47,23 +47,27 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
     private var dismissAnimation: (() -> ())? = nil
     private var dismissCompletion: ((Bool) -> ())? = nil
 	
+    private var dismissThreshold: CGFloat = 0
+    
     // MARK: - Initializers
     
     convenience init(presentedViewController: UIViewController,
                      presenting presentingViewController: UIViewController?,
                      isSwipeToDismissGestureEnabled: Bool,
+                     dismissThreshold: CGFloat,
                      presentAnimation: (() -> ())? = nil,
                      presentCompletion: ((Bool) ->())? = nil,
                      dismissAnimation: (() -> ())? = nil,
                      dismissCompletion: ((Bool) -> ())? = nil) {
-        self.init(presentedViewController: presentedViewController,
-                  presenting: presentingViewController)
+        
+        self.init(presentedViewController: presentedViewController, presenting: presentingViewController)
         
         self.isSwipeToDismissGestureEnabled = isSwipeToDismissGestureEnabled
         self.presentAnimation = presentAnimation
         self.presentCompletion = presentCompletion
         self.dismissAnimation = dismissAnimation
         self.dismissCompletion = dismissCompletion
+        self.dismissThreshold = dismissThreshold
         
         NotificationCenter.default.addObserver(self, selector: #selector(updateForStatusBar), name: .UIApplicationDidChangeStatusBarFrame, object: nil)
     }
@@ -609,8 +613,6 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
     private func updatePresentedViewForTranslation(inVerticalDirection translation: CGFloat) {
         
         let elasticThreshold: CGFloat = 120
-        let dismissThreshold: CGFloat = 240
-        
         let translationFactor: CGFloat = 1/2
         
         /// Nothing happens if the pan gesture is performed from bottom

--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -48,6 +48,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
     private var dismissCompletion: ((Bool) -> ())? = nil
 	
     private var dismissThreshold: CGFloat = 0
+    private var extraVerticalInset: CGFloat = 0
     
     // MARK: - Initializers
     
@@ -55,6 +56,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
                      presenting presentingViewController: UIViewController?,
                      isSwipeToDismissGestureEnabled: Bool,
                      dismissThreshold: CGFloat,
+                     extraVerticalInset: CGFloat,
                      presentAnimation: (() -> ())? = nil,
                      presentCompletion: ((Bool) ->())? = nil,
                      dismissAnimation: (() -> ())? = nil,
@@ -68,6 +70,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
         self.dismissAnimation = dismissAnimation
         self.dismissCompletion = dismissCompletion
         self.dismissThreshold = dismissThreshold
+        self.extraVerticalInset = extraVerticalInset
         
         NotificationCenter.default.addObserver(self, selector: #selector(updateForStatusBar), name: .UIApplicationDidChangeStatusBarFrame, object: nil)
     }
@@ -97,7 +100,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
             return .zero
         }
         
-        let yOffset = ManualLayout.presentingViewTopInset + Constants.insetForPresentedView
+        let yOffset = ManualLayout.presentingViewTopInset + Constants.insetForPresentedView + extraVerticalInset
         
         return CGRect(x: 0,
                       y: yOffset,

--- a/Source/DeckTransitioningDelegate.swift
+++ b/Source/DeckTransitioningDelegate.swift
@@ -36,6 +36,8 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
     
     /// Determines how far the modal view controller needs to be swiped before its dismissed.
     public var dismissThreshold: CGFloat = 240
+    /// Extra vertical padding between the status bar and the content view
+    public var extraVerticalInset: CGFloat = 0
     
     // MARK: - Initializers
     
@@ -59,6 +61,7 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
     ///		dismissed
     @objc public init(isSwipeToDismissEnabled: Bool = true,
                       dismissThreshold: NSNumber? = nil,
+                      extraVerticalInset: NSNumber? = nil,
                       presentDuration: NSNumber? = nil,
                       presentAnimation: (() -> ())? = nil,
                       presentCompletion: ((Bool) -> ())? = nil,
@@ -75,6 +78,9 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
         
         if let threshold = dismissThreshold {
             self.dismissThreshold = CGFloat(threshold.doubleValue)
+        }
+        if let verticalInset = extraVerticalInset {
+            self.extraVerticalInset = CGFloat(verticalInset.doubleValue)
         }
     }
     
@@ -122,6 +128,7 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
             presenting: presenting,
             isSwipeToDismissGestureEnabled: isSwipeToDismissEnabled,
             dismissThreshold: dismissThreshold,
+            extraVerticalInset: extraVerticalInset,
             presentAnimation: presentAnimation,
             presentCompletion: presentCompletion,
             dismissAnimation: dismissAnimation,

--- a/Source/DeckTransitioningDelegate.swift
+++ b/Source/DeckTransitioningDelegate.swift
@@ -34,6 +34,9 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
     private let dismissAnimation: (() -> ())?
     private let dismissCompletion: ((Bool) -> ())?
     
+    /// Determines how far the modal view controller needs to be swiped before its dismissed.
+    public var dismissThreshold: CGFloat = 240
+    
     // MARK: - Initializers
     
     /// Returns a transitioning delegate to perform a Deck transition. All
@@ -55,6 +58,7 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
     ///   - dismissCompletion: A block that will be run after the card has been
     ///		dismissed
     @objc public init(isSwipeToDismissEnabled: Bool = true,
+                      dismissThreshold: NSNumber? = nil,
                       presentDuration: NSNumber? = nil,
                       presentAnimation: (() -> ())? = nil,
                       presentCompletion: ((Bool) -> ())? = nil,
@@ -68,6 +72,10 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
         self.dismissDuration = dismissDuration?.doubleValue
         self.dismissAnimation = dismissAnimation
         self.dismissCompletion = dismissCompletion
+        
+        if let threshold = dismissThreshold {
+            self.dismissThreshold = CGFloat(threshold.doubleValue)
+        }
     }
     
     // MARK: - UIViewControllerTransitioningDelegate
@@ -113,6 +121,7 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
             presentedViewController: presented,
             presenting: presenting,
             isSwipeToDismissGestureEnabled: isSwipeToDismissEnabled,
+            dismissThreshold: dismissThreshold,
             presentAnimation: presentAnimation,
             presentCompletion: presentCompletion,
             dismissAnimation: dismissAnimation,


### PR DESCRIPTION
For #75.

In my app some testers were finding the swipe to dismiss to be too difficult to complete. I tweaked the `dismissThreshold` to 120 and found that this made it much easier for them.

With these changes you can now pass in an optional threshold, e.g.

```swift
let transitionDelegate = DeckTransitioningDelegate(dismissThreshold: 120)
```