### PR TITLE
Calculating content's height according to it's internal constraints

### DIFF
--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -75,6 +75,26 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
     }
     
     // MARK: - Sizing
+
+    private lazy var modalHeight: CGFloat = {
+        guard let containerView = containerView else { return 0 }
+
+        let contentHeight: CGFloat
+        if  let navController = presentedViewController as? UINavigationController,
+            let rootViewController = navController.viewControllers.first {
+
+            let rootVCSize = rootViewController.view.systemLayoutSizeFitting(CGSize(width: containerView.bounds.width, height: 0))
+            let navBarSize = navController.navigationBar.bounds.size
+            contentHeight = rootVCSize.height + navBarSize.height
+        } else {
+
+            let presentedVCSize = presentedViewController.view.systemLayoutSizeFitting(CGSize(width: containerView.bounds.width, height: 0))
+            contentHeight = presentedVCSize.height
+        }
+
+        let fullHeight = containerView.bounds.height - (ManualLayout.presentingViewTopInset + Constants.insetForPresentedView)
+        return contentHeight > 0 ? min(fullHeight, contentHeight) : fullHeight
+    }()
     
     private var statusBarHeight: CGFloat {
         return UIApplication.shared.statusBarFrame.height
@@ -92,13 +112,11 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
         guard let containerView = containerView else {
             return .zero
         }
-        
-        let yOffset = ManualLayout.presentingViewTopInset + Constants.insetForPresentedView
-        
+
         return CGRect(x: 0,
-                      y: yOffset,
+                      y: containerView.bounds.height - modalHeight,
                       width: containerView.bounds.width,
-                      height: containerView.bounds.height - yOffset)
+                      height: modalHeight)
     }
 	
 	// MARK: - Presentation
@@ -608,8 +626,8 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
     ///   the container view in the vertical direction
     private func updatePresentedViewForTranslation(inVerticalDirection translation: CGFloat) {
         
-        let elasticThreshold: CGFloat = 120
-        let dismissThreshold: CGFloat = 240
+        let elasticThreshold: CGFloat = modalHeight / 6
+        let dismissThreshold: CGFloat = modalHeight / 3
         
         let translationFactor: CGFloat = 1/2
         


### PR DESCRIPTION
Calculating content's height according to it's internal constraints and using that as the modal's height. If the constraints are not properly set, i.e. when `systemLayoutSizeFitting` returns a height of 0 we use the default height.