### PR TITLE
Added segue customization for storyboards

### DIFF
--- a/Source/DeckSegue.swift
+++ b/Source/DeckSegue.swift
@@ -13,13 +13,18 @@ import UIKit
 /// To use this, set your segue's class to `DeckSegue`, and its `kind` to
 /// `custom`
 public final class DeckSegue: UIStoryboardSegue {
-    
-    var transition: UIViewControllerTransitioningDelegate?
-    
+
+    /// You can customize the segue transition by providing your own
+    /// DeckTransitioningDelegate in 'prepare(for segue: sender:)'
+    /// i.e.
+    /// (segue as? DeckSegue)?.transitioningDelegate
+    ///     = DeckTransitioningDelegate(isSwipeToDismissEnabled: false)
+    public var transitioningDelegate: DeckTransitioningDelegate?
+
     /// Performs the visual transition for the Deck segue.
     public override func perform() {
-        transition = DeckTransitioningDelegate()
-        destination.transitioningDelegate = transition
+        transitioningDelegate = transitioningDelegate ?? DeckTransitioningDelegate()
+        destination.transitioningDelegate = transitioningDelegate
         destination.modalPresentationStyle = .custom
         source.present(destination, animated: true, completion: nil)
     }


### PR DESCRIPTION
This allows the customization of the deck segue when utilizing storyboards.

To customize the deck segue, simply set a DeckTransitioningDelegate instance configured how you would like.

**Example:**
```(segue as? DeckSegue)?.transitioningDelegate = DeckTransitioningDelegate(isSwipeToDismissEnabled: false)```)


Previous to this, when using a deck transition set up in storyboards it always got created with the default parameters.