### PR TITLE
Add swift_version to podspec

### DIFF
--- a/DeckTransition.podspec
+++ b/DeckTransition.podspec
@@ -16,4 +16,6 @@ Pod::Spec.new do |spec|
   spec.framework        = 'UIKit'
   spec.ios.deployment_target = '9.0'
 
+  spec.swift_version = "4.2"
+
 end


### PR DESCRIPTION
Believe CocoaPods uses this for selecting the language version since 1.4.0 rather than the `.swift_version` file.