### PR TITLE
Integrated haptic feedback coordinated with transitions

### DIFF
--- a/DeckTransition.xcodeproj/project.pbxproj
+++ b/DeckTransition.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A111724221A6E224005D0898 /* DeckHapticFeedbackGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A111724121A6E224005D0898 /* DeckHapticFeedbackGenerator.swift */; };
 		D93F1CA21EAEDB6E009A7474 /* DeckTransition.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D93F1C981EAEDB6E009A7474 /* DeckTransition.framework */; };
 		D93F1CA71EAEDB6E009A7474 /* DeckTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93F1CA61EAEDB6E009A7474 /* DeckTransitionTests.swift */; };
 		D93F1CA91EAEDB6E009A7474 /* DeckTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = D93F1C9B1EAEDB6E009A7474 /* DeckTransition.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -45,6 +46,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A111724121A6E224005D0898 /* DeckHapticFeedbackGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckHapticFeedbackGenerator.swift; sourceTree = "<group>"; };
 		D93F1C981EAEDB6E009A7474 /* DeckTransition.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DeckTransition.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D93F1C9B1EAEDB6E009A7474 /* DeckTransition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeckTransition.h; sourceTree = "<group>"; };
 		D93F1C9C1EAEDB6E009A7474 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 				E8683D8B1F3447A5005C7E9A /* DeckDismissingAnimationController.swift */,
 				E8B20A911FD84F1500648C9A /* DeckSnapshotUpdater.swift */,
 				E8B271611FD7E117009883B2 /* DeckTransitionViewControllerProtocol.swift */,
+				A111724121A6E224005D0898 /* DeckHapticFeedbackGenerator.swift */,
 				E8B271651FD7E208009883B2 /* ScrollViewDetector.swift */,
 				E8B271671FD7E20F009883B2 /* ScrollViewUpdater.swift */,
 				E857980F1F34D63200C6CABE /* Constants.swift */,
@@ -246,7 +249,6 @@
 				TargetAttributes = {
 					D93F1C971EAEDB6E009A7474 = {
 						CreatedOnToolsVersion = 8.3.2;
-						DevelopmentTeam = BM5Y87HJ2F;
 						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
@@ -306,6 +308,7 @@
 				E8683D821F34471B005C7E9A /* DeckPresentingAnimationController.swift in Sources */,
 				E87B47281F6E799D004AA6C7 /* Corner.swift in Sources */,
 				E87B47261F6E7983004AA6C7 /* CGRect+Corners.swift in Sources */,
+				A111724221A6E224005D0898 /* DeckHapticFeedbackGenerator.swift in Sources */,
 				E8683D881F344793005C7E9A /* DeckSegue.swift in Sources */,
 				E8B271641FD7E145009883B2 /* UIViewController+DeckTransitionViewControllerProtocol.swift in Sources */,
 				E8B271681FD7E20F009883B2 /* ScrollViewUpdater.swift in Sources */,
@@ -464,7 +467,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = BM5Y87HJ2F;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -485,7 +488,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = BM5Y87HJ2F;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/DeckTransition.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/DeckTransition.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -137,7 +137,6 @@
 				TargetAttributes = {
 					D93F1CBF1EAEDD3F009A7474 = {
 						CreatedOnToolsVersion = 8.3.2;
-						DevelopmentTeam = BM5Y87HJ2F;
 						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
@@ -316,7 +315,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BM5Y87HJ2F;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.harshilshah.DeckTransition-Example-Wat";
@@ -332,7 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BM5Y87HJ2F;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.harshilshah.DeckTransition-Example-Wat";

--- a/Example/Source/ModalViewController.swift
+++ b/Example/Source/ModalViewController.swift
@@ -46,6 +46,13 @@ class ModalViewController: UIViewController {
     @objc func viewWasTapped() {
         let modal = ModalViewController()
         let transitionDelegate = DeckTransitioningDelegate()
+        
+        // If the API is available, configure haptic feedback for presentation and dismissal.
+        if #available(iOS 10.0, *) {
+            transitionDelegate.useHapticFeedback(at: [.whenDismissing, .whenPresenting])
+            transitionDelegate.changeFeedbackStyle(to: .heavy)
+        }
+        
         modal.transitioningDelegate = transitionDelegate
         modal.modalPresentationStyle = .custom
         present(modal, animated: true, completion: nil)

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -36,6 +36,12 @@ class ViewController: UIViewController {
     @objc func viewWasTapped() {
         let modal = ModalViewController()
         let transitionDelegate = DeckTransitioningDelegate()
+        
+        // If the API is available, configure haptic feedback for presentation and dismissal.
+        if #available(iOS 10.0, *) {
+            transitionDelegate.useHapticFeedback(at: [.whenDismissing, .whenPresenting])
+        }
+        
         modal.transitioningDelegate = transitionDelegate
         modal.modalPresentationStyle = .custom
         present(modal, animated: true, completion: nil)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ You can also choose to update snapshot directly from the presenting view control
 
 It's worth noting that updating the snapshot is an expensive process and should only be used if necessary, for example if you are updating your entire app's theme.
 
+### Haptic Feedback
+The device's TapticEngine can be used to perform haptic feedback when the presentation or dismissal transition is done *(like Overcast does with its version 5)*. To configure haptic feedback, call ```DeckTransitioningDelegate.useHapticFeedback(at:)```.
+Currently supported points of feedback are ```.whenPresenting```, ```.whenDismissing``` and ```.whenPresentingIsFinished```.
+```swift
+let modal = ModalViewController()
+let transitionDelegate = DeckTransitioningDelegate()
+if #available(iOS 10.0, *) {
+    transitionDelegate.useHapticFeedback(at: [.whenDismissing, .whenPresenting])
+}
+modal.transitioningDelegate = transitionDelegate
+        modal.modalPresentationStyle = .custom
+        present(modal, animated: true, completion: nil)
+```
+Haptic feedback was implemented by [Andreas Neusüß](https://github.com/Tantalum73).
+
 ## Apps Using DeckTransition
 - [Petty](https://zachsim.one/projects/petty) by [Zach Simone](https://twitter.com/zachsimone)
 - [Bitbook](https://bitbookapp.com) by [Sammy Gutierrez](https://sammygutierrez.com)

--- a/Source/DeckHapticFeedbackGenerator.swift
+++ b/Source/DeckHapticFeedbackGenerator.swift
@@ -1,0 +1,89 @@
+//
+//  DeckHapticFeedbackGenerator.swift
+//  DeckTransition
+//
+//  Created by Andreas Neusüß on 22.11.18.
+//  Copyright © 2018 Harshil Shah. All rights reserved.
+//
+
+import UIKit
+
+/** This class is used to control the haptic feedback. It provides methods for configuring the style of the feedback. Currently, only impact-styled feedbacks are supported (with weight ```light```, ```medium``` or ```heavy```).
+ 
+ This class provides a singleton. The reson for this is that ```UIImpactFeedbackGenerator``` is only available on iOS 10 and newer. Additionally, a reference to it must be stored strongly. Otherwise the feedback will not be performed. Swift does not allow stored properties to be marked ```@available``` and therefore either the entire class that uses the feedback-generator must be marked ```@available``` or the ```UIImpactFeedbackGenerator``` needs to be encapsulated. This class uses the secound approach.
+ In doing so, only small function calls needs to be wrapped in ```if #available``` checks.
+ The downside of this approach is that only one kind of feedback can be performed.
+ 
+ Please ensure to call ```DeckHapticFeedbackGenerator.shared.prepare()``` to power up the device's TapticEngine.
+ */
+@available(iOS 10.0, *)
+final class DeckHapticFeedbackGenerator: NSObject {
+    
+    /// The singleton that should be used to trigger haptic feedback. Please ensure to call ```DeckHapticFeedbackGenerator.shared.prepare()``` to power up the device's TapticEngine.
+    static let shared = DeckHapticFeedbackGenerator()
+    
+    /// The feedback style that should be performed.
+    var style: UIImpactFeedbackGenerator.FeedbackStyle = .light {
+        didSet {
+            feedbackGenerator = createFeedbackGenerator(using: style)
+        }
+    }
+    
+    // Make the initializer unavailable for the public so that the shared instance is used.
+    private override init() {
+        super.init()
+        feedbackGenerator = createFeedbackGenerator(using: style)
+    }
+    
+    /// The internally used feedback generator. Must be held strongly in order to perform feedback. Make sure to call ```prepare``` prior to any feedback action.
+    private var feedbackGenerator: UIImpactFeedbackGenerator?
+    
+    
+    /// This method constructs a UIImpactFeedbackGenerator from a given feedback style.
+    ///
+    /// - Parameter style: The style that should be used for the feedback.
+    /// - Returns: The new UIImpactFeedbackGenerator.
+    private func createFeedbackGenerator(using style: UIImpactFeedbackGenerator.FeedbackStyle) -> UIImpactFeedbackGenerator {
+        return UIImpactFeedbackGenerator(style: style)
+    }
+
+    
+    /// This method prepares the device's TapticEngine. Call this method about one second before the haptic feedback should be performed`(if possible). The TapticEngine will stay powered on about one or two seconds.
+    func prepare() {
+        feedbackGenerator?.prepare()
+    }
+    
+    /// This method performs the haptic feedback. Please call ```prepare``` about one second in advance. Only then it is save to coordinate UI interactions with the haptic feedback. It will use the style provided by a call to ```DeckHapticFeedbackGenerator`.shared.changeFeedbackStyle(to:)```.
+    func perform() {
+        // If not done already, a call to "prepare" poweres up the TapticEngine.
+        prepare()
+        
+        feedbackGenerator?.impactOccurred()
+    }
+    
+    
+    /// This method changed the style of the haptic feedback.
+    ///
+    /// - Parameter style: The new style that should be used for the feedback.
+    func changeFeedbackStyle(to style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        self.style = style
+    }
+}
+
+// Use an extension to encapsulate feedback providing. In doing so, every @availability checking can be performed in this extension.
+
+extension DeckPresentationController {
+    
+    /// Performs the haptic feedback.
+    func prepareHapticFeedback() {
+        if #available(iOS 10.0, *) {
+            DeckHapticFeedbackGenerator.shared.prepare()
+        }
+    }
+    /// Prepares the TapticEngine to perform haptic feedback in the near future (lasts up to two seconds).
+    func performHapticFeedback() {
+        if #available(iOS 10.0, *) {
+            DeckHapticFeedbackGenerator.shared.perform()
+        }
+    }
+}

--- a/Source/DeckTransitioningDelegate.swift
+++ b/Source/DeckTransitioningDelegate.swift
@@ -8,6 +8,38 @@
 
 import UIKit
 
+
+/// This OptionSet makes it possible to determine points where haptic feedback should be performed. If passed into the corresponding method ```DeckTransitioningDelegate.useHapticFeedback(at:)```, the system will provide haptic feedback as configured.
+public struct HapticFeedbackOptions: OptionSet {
+    //Using an option set allows to configure multiple values and many combinations. An enum can not provide that level of flexibility. However, a OptionSet can not be bridged into Objective-C and therefore, a fallback needs to be implemented.
+    
+    
+    public let rawValue: Int
+    
+    /// Haptic feedback will be performed when the presented ViewController is about to start animating onto screen.
+    public static let whenPresenting = HapticFeedbackOptions(rawValue: 1 << 0)
+    
+    /// Haptic feedback will be performed when the presented ViewController is about to start animating off screen.
+    public static let whenDismissing = HapticFeedbackOptions(rawValue: 1 << 1)
+    
+    /// Haptic feedback will be performed when the presented ViewController is done with its animated appearance and snapped into place.
+    public static let whenPresentingIsFinished = HapticFeedbackOptions(rawValue: 1 << 2)
+    
+    /// Haptic feedback will be performed when the presented ViewController is done with its animated dismissal and therefore removed from the view hierarchy.
+    public static let whenDismissingIsFinished = HapticFeedbackOptions(rawValue: 1 << 3)
+
+    /// All cases of the OptionSet.
+    static var allCases: HapticFeedbackOptions {
+        return [HapticFeedbackOptions.whenPresenting, HapticFeedbackOptions.whenDismissing, HapticFeedbackOptions.whenPresentingIsFinished, HapticFeedbackOptions.whenDismissingIsFinished]
+    }
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+}
+
+
 /// The DeckTransitioningDelegate class vends out the presentation and animation
 /// controllers required to present a view controller with the Deck transition
 /// style
@@ -33,8 +65,9 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
     private let dismissDuration: TimeInterval?
     private let dismissAnimation: (() -> ())?
     private let dismissCompletion: ((Bool) -> ())?
+    private var hapticFeedbackOptions: HapticFeedbackOptions
     
-    // MARK: - Initializers
+    // MARK: - Initializers and Configuration
     
     /// Returns a transitioning delegate to perform a Deck transition. All
     /// parameters are optional. Swipe-to-dimiss is enabled by default. Leaving
@@ -47,20 +80,20 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
     ///	  - presentDuration: The duration for the presentation animation
     ///   - presentAnimation: An animation block that will be performed
     ///		alongside the card presentation animation
-    ///   - presentCompletion: A block that will be run after the card has been
-    ///		presented
+    ///   - presentCompletion: A block that will be run after the card has been presented
     ///	  - dismissDuration: The duration for the dismissal animation
     ///   - dismissAnimation: An animation block that will be performed
     ///		alongside the card dismissal animation
-    ///   - dismissCompletion: A block that will be run after the card has been
-    ///		dismissed
+    ///   - dismissCompletion: A block that will be run after the card has been dismissed
+    ///   - shouldUseHapticFeedback: A flag that determines if haptic feedback should be given when the presentation or dismissal is performed. Currently, there is no way to specify options for the feedback in Objective-C, as the used Swift "OptionSet" type can not be exposed. The initializer is marked "@objc" and therefore exposing the options is not possible. As this initializer is marked "@objc", OptionSets can not be used as they can not be bridged into Objective-C. Due to this fact, the mentioned flag is introduced to provide a basic support for haptic feedback under Objective-C. If you are using Swift, please use ```DeckTransitioningDelegate.useHapticFeedback(at:)``` to configure the haptic feedback.
     @objc public init(isSwipeToDismissEnabled: Bool = true,
                       presentDuration: NSNumber? = nil,
                       presentAnimation: (() -> ())? = nil,
                       presentCompletion: ((Bool) -> ())? = nil,
                       dismissDuration: NSNumber? = nil,
                       dismissAnimation: (() -> ())? = nil,
-                      dismissCompletion: ((Bool) -> ())? = nil) {
+                      dismissCompletion: ((Bool) -> ())? = nil,
+                      shouldUseHapticFeedback: Bool = false) {
         self.isSwipeToDismissEnabled = isSwipeToDismissEnabled
         self.presentDuration = presentDuration?.doubleValue
         self.presentAnimation = presentAnimation
@@ -68,6 +101,31 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
         self.dismissDuration = dismissDuration?.doubleValue
         self.dismissAnimation = dismissAnimation
         self.dismissCompletion = dismissCompletion
+        
+        // Convert the provided flag to the internal OptionSet "HapticFeedbackOptions". As this initializer is marked "@objc", OptionSets can not be used as they can not be bridged into Objective-C. Due to this fact, the mentioned flag is introduced to provide a basic support for haptic feedback under Objective-C. The flag is obsolete once Objective-C support is dropped, since the OptionSet type provides more functionality (like combining multiple cases like .whenPresenting AND .whenDismissing, which is not expressible using enums).
+        if shouldUseHapticFeedback {
+            self.hapticFeedbackOptions = [.whenPresenting, .whenDismissing]
+        }
+        else {
+            self.hapticFeedbackOptions = []
+        }
+    }
+
+    
+    /// This method configures at which points a haptic feedback should be performed. It must be called prior to the transition in order to be taken into consideration.
+    ///
+    /// - Parameter options: The options that specify at which points haptic feedback should be performed.
+    @available(iOS 10.0, *)
+    public func useHapticFeedback(at options: HapticFeedbackOptions) {
+        hapticFeedbackOptions = options
+    }
+    
+    /// This method changes the style of the haptic feedback. The latest provided value is used throughout all ongoing transitions.
+    ///
+    /// - Parameter style: The style that the hatic feedback generator should use.
+    @available(iOS 10.0, *)
+    public func changeFeedbackStyle(to style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        DeckHapticFeedbackGenerator.shared.changeFeedbackStyle(to: style)
     }
     
     // MARK: - UIViewControllerTransitioningDelegate
@@ -116,7 +174,8 @@ public final class DeckTransitioningDelegate: NSObject, UIViewControllerTransiti
             presentAnimation: presentAnimation,
             presentCompletion: presentCompletion,
             dismissAnimation: dismissAnimation,
-            dismissCompletion: dismissCompletion)
+            dismissCompletion: dismissCompletion,
+            hapticFeedbackOptions: hapticFeedbackOptions)
         presentationController.transitioningDelegate = self
         return presentationController
     }


### PR DESCRIPTION
This pull requests integrates haptic feedback into the project. The feedback is coordinated alongside with the transitions.
As the updated sample project shows, the points at which feedback should be provided are configured by calling ```transitionDelegate.useHapticFeedback(at: [.whenDismissing, .whenPresenting])```.

In my experience, haptic feedback is a great way to provide context to what is going on on-screen. Even Overcast added force feedback for its v5.0 re-design. 
Prior to this pull request, one needed to coordinate haptic feedback by themselves in the ```viewWillAppear``` and ```viewWillDisappear``` methods of the presented ViewController.
Now it is much easier to integrate it into the transition.

I would love to hear your thoughts on it! 🙂