### PR TITLE
Make scrollview detector work with WKWebViews

### DIFF
--- a/Source/ScrollViewDetector.swift
+++ b/Source/ScrollViewDetector.swift
@@ -59,13 +59,29 @@ final class ScrollViewDetector {
             return scrollView
         }
         
-        for subview in viewController.view.subviews {
-            if let scrollView = subview as? UIScrollView {
-                return scrollView
-            }
+        if let scrollView = self.getScrollView(from: viewController.view) {
+            return scrollView
         }
         
         return nil
     }
-    
+
+    private func getScrollView(from view: UIView) -> UIScrollView? {
+        let webViewClass: AnyClass? = NSClassFromString("WKWebView")
+        for subview in view.subviews {
+            if let scrollView = subview as? UIScrollView {
+                return scrollView
+            }
+
+            if let webViewClass = webViewClass,
+                subview.isKind(of: webViewClass),
+                subview.responds(to: Selector("scrollView")),
+                let scrollView = subview.value(forKey: "scrollView") as? UIScrollView
+            {
+                return scrollView
+            }
+        }
+
+        return nil
+    }
 }


### PR DESCRIPTION
Right now, if your view has a subview which is a WKWebView, the scrollview detector will not find its scrollview because it only looks one level deep, and WKWebView itself is not a scrollview (the scrollview is one of its subviews). This change checks to see if each subview is an instance of WKWebView and when it finds one that is, it returns its scroll view. I used NSClassFromString and selectors rather than just checking with as? WKWebView because doing so would require linking WebKit which not everyone will want to do. Another possible approach would be searching two levels deep, but in complex hierarchies that could get expensive.