### PR TITLE
Implement shouldTransition(for scrollView: UIScrollView?) delegate method

### DIFF
--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -561,6 +561,10 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
             return
         }
         
+        if let deckViewController = presentedViewController as? DeckTransitionViewControllerProtocol {
+            guard deckViewController.shouldTransition!(for: ScrollViewDetector(withViewController: presentedViewController).scrollView) else { return }
+        }
+        
         switch gestureRecognizer.state {
         
         case .began:

--- a/Source/DeckTransitionViewControllerProtocol.swift
+++ b/Source/DeckTransitionViewControllerProtocol.swift
@@ -57,5 +57,11 @@ import UIKit
     ///   `childViewControllerForDeck` variable is also implemented.
     @objc optional var scrollViewForDeck: UIScrollView { get }
     
+    /// Calls a delegate method to determine whether or not a Deck transition
+    /// should take place.
+    
+    /// - Note: Default for this method always returns `true`
+    @objc optional func shouldTransition(for scrollView: UIScrollView?) -> Bool
+    
 }
 


### PR DESCRIPTION
I had a need to be able to govern from the _presented view controller_ whether or not a particular scroll view should respond and interactively dismiss the controller. This was driven from a need to handle a re-orderable table view, and the long-press/drag gesture was being intercepted, and closing the view.

Simple implementation of this delegate, for example in my case, I needed to block the transition if my tableView is editing:

```
extension ModalViewController: DeckTransitionViewControllerProtocol {
    func shouldTransition(for scrollView: UIScrollView?) -> Bool {
        return !editHistoryTableView.isReordering // returns true if the table view is not editing
    }
}
```